### PR TITLE
Add `show --stat` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ using `folke/lazy.nvim`
 {
 	"yutkat/git-rebase-auto-diff.nvim",
 	ft = { "gitrebase" },
-	opts = {},
+	opts = {
+		size = vim.fn.float2nr(vim.o.lines * 0.5),
+		run_show = false,
+	},
 }
 ```
 

--- a/lua/git-rebase-auto-diff/init.lua
+++ b/lua/git-rebase-auto-diff/init.lua
@@ -1,6 +1,7 @@
 local M = {}
 local config = {
 	size = vim.fn.float2nr(vim.o.lines * 0.5),
+	run_show = false,
 }
 local buf = nil
 
@@ -43,7 +44,11 @@ function M.preview()
 	if hash == "" then
 		return
 	end
-	require("git-rebase-auto-diff").run("git --no-pager diff " .. hash .. "^!")
+	local cmd = "git --no-pager diff " .. hash .. "^!"
+	if config.run_show then
+		cmd = "git --no-pager show --stat " .. hash .. " && echo '' && " .. cmd
+	end
+	require("git-rebase-auto-diff").run(cmd)
 end
 
 local function create_autocmds()
@@ -71,7 +76,7 @@ end
 
 function M.setup(opts)
 	opts = opts or {}
-	config = vim.tbl_deep_extend("keep", opts, config)
+	config = vim.tbl_deep_extend("force", config, opts or {})
 	create_autocmds()
 end
 


### PR DESCRIPTION
Add a simple option to run `git show --stat <hash>` before the diff, disabled by default.